### PR TITLE
Remove symbolic links

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-README.md

--- a/README.illumos
+++ b/README.illumos
@@ -1,1 +1,0 @@
-README.solaris


### PR DESCRIPTION
There are two READMEs which are used as symbolic links. This causes problems when building libfswatch on Windows.

TN: U107-002